### PR TITLE
Add retries to kstatus and other bugfixes

### DIFF
--- a/cosmos/models/Task.py
+++ b/cosmos/models/Task.py
@@ -109,6 +109,7 @@ def task_status_changed(task):
         task.finished_on = datetime.datetime.now()
         if all(t.successful or not t.must_succeed for t in task.stage.tasks):
             task.stage.status = StageStatus.successful
+        task.session.commit()
 
 
 # task_edge_table = Table('task_edge', Base.metadata,

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -528,7 +528,10 @@ def _run(workflow, session, task_queue):
             available_cores = False
 
         for task in _process_finished_tasks(workflow.jobmanager):
-            if task.status == TaskStatus.failed and task.must_succeed:
+            if task.status == TaskStatus.failed and not task.must_succeed:
+                pass  # it's ok if the task failed
+
+            elif task.status == TaskStatus.failed and task.must_succeed:
 
                 if workflow.info['fail_fast']:
                     workflow.log.info('%s Exiting run loop at first Task failure, exit_status: %s: %s',


### PR DESCRIPTION
1. Added retries to the `kstatus` call, modeled after the retries for slurm: https://github.com/LPM-HMS/COSMOS2/blob/master/cosmos/job/drm/drm_slurm.py#L108
This should help avoid a `RuntimeError: Unable to connect to the server` that we occasionally see when using `k8s-jobs` drm

2. Added a conditional case when checking a task status for when the Task failed, but `must_succeed` is `False`. Otherwise, in this case an `AssertionError: Unexpected finished task status` would be raised

3. Added a commit to the sqlite db if a Task status is successful. When using `k8s-jobs` drm, we set up a function to sync the working dir (including the cosmos sqlite) to GCS on a task status change. As-is, the sqlite would be synced with the status set as "Submitted", not "Successful" because the "Successful" status change was not committed yet. This was an issue if we had to cancel a run in the middle and then resume later - it would end up re-running up to hundreds of tasks because the "Successful" status was not committed.