### PR TITLE
Add custom docker mount points

### DIFF
--- a/cosmos/models/Task.py
+++ b/cosmos/models/Task.py
@@ -209,6 +209,9 @@ class Task(Base):
     __table_args__ = (UniqueConstraint("stage_id", "uid", name="_uc1"),)
     drm_options = {}
 
+    mount_points = []
+    volumes = []
+
     id = Column(Integer, primary_key=True)
     uid = Column(String(255), index=True)
 

--- a/cosmos/models/Workflow.py
+++ b/cosmos/models/Workflow.py
@@ -212,6 +212,8 @@ class Workflow(Base):
         drm_options=None,
         environment_variables=None,
         if_duplicate="raise",
+        mount_points=None,
+        volumes=None,
     ):
         """
         Adds a new Task to the Workflow.  If the Task already exists (and was successful), return the successful Task stored in the database
@@ -352,6 +354,15 @@ class Workflow(Base):
             )
 
             task.cmd_fxn = func
+
+            # for awsbatch add custom volumes to container
+            # leave empty list if not specified
+            if mount_points is None or volumes is None:
+                task.mount_points = []
+                task.volumes = []
+            else:
+                task.mount_points = mount_points
+                task.volumes = volumes
 
             if drm_options is None:
                 task.drm_options = {}


### PR DESCRIPTION
I add the possibility to specify custom mount points and volumes as task properties for docker images. User can now use the same format it was used for the default volumes to add his owns. For example:

```
t = workflow.add_task(
            func=get_instance_info,
            params=dict(args.out_s3_uri),
            uid="get_instance_info",
            time_req=None,
            max_attempts=args.max_attempts,
            core_req=1,
            mem_req=1*1024,
            queue=args.default_queue,
            mount_points=[{"containerPath": "/tmp", "readOnly": False, "sourceVolume": "tmp"}, 
                        {"containerPath": "/var", "readOnly": False, "sourceVolume": "var"}],
            volumes=[{"name": "tmp", "host": {"sourcePath": "/tmp"}},
                    {"name": "var", "host": {"sourcePath": "/var"}}],
```

Meanwhile I removed the argv parameter in awsbatch job definition to avoid to get errors when argument list exceeds 255 in length.

The main issue was to fit the format of the mount points and volumes to the iteration with set() in the submit_job function. 

Looking forward to feedbacks
